### PR TITLE
Add __pycache__/ to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb*
 puf.csv
+__pycache__/


### PR DESCRIPTION
This pull request adds the `__pycache__` directory to the `.gitignore` file so that a `git status` command does not show that directory as an untracked file.