### PR TITLE
Finish NID refactoring

### DIFF
--- a/debt.py
+++ b/debt.py
@@ -54,6 +54,10 @@ class Debt():
                 raise ValueError('Wrong response')
         else:
             self.response = np.zeros(14)
+        if corp:
+            self.delta = np.array(self.data.econ_defaults['f_c']) * (1 + self.response)
+        else:
+            self.delta = np.array(self.data.econ_defaults['f_nc']) * (1 + self.response)
         if len(asset_forecast) == 14:
             self.asset_forecast = asset_forecast
         else:
@@ -112,7 +116,7 @@ class Debt():
             K_fa.append(K_fa[56] * self.asset_forecast[i-54] /
                         self.asset_forecast[2])
             A.append(A[56] * K_fa[i] / K_fa[56])
-            D.append(D[56] * K_fa[i] / K_fa[56] * (1 + self.response[i-54]))
+            D.append(D[56] * K_fa[i] / K_fa[56] * self.delta[i-54] / self.delta[2])
             L.append(D[i] + A[i])
         # Save level histories
         self.net_debt_history = D

--- a/passthrough.py
+++ b/passthrough.py
@@ -252,7 +252,7 @@ class PassThrough():
         """
         Replaces the Debt object to use the new asset forecast and Data
         """
-        pctch_delta = np.array(responses.debt_responses['pchDelta_corp'])
+        pctch_delta = np.array(responses.debt_responses['pchDelta_noncorp'])
         self.debt = Debt(self.btax_params, self.other_params,
                          self.asset.get_forecast(), data=self.data, 
                          response=pctch_delta, corp=False)


### PR DESCRIPTION
This PR completes the process of refactoring the net interest model as described in #43. This switches the advancing of the debt during the budget window to use a forecast for delta instead of just advancing by assets and then including the response. This has no effect on the tests or the baseline; its only relevance will be once BRC switches to using the TCJA's behavioral effects (specifically, on optimal debt) as the baseline. 

I also fixed a small error in the pass-through response, which was not yet being tested.

